### PR TITLE
Updated comment handling in backend

### DIFF
--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -1,10 +1,21 @@
 const express = require('express')
 const comment = express.Router()
 const CommentModel = require('../models/commentModel')
+const commentSeed = require('../models/commentsSeed')
 
-//index
-comment.get('/', (req, res) => {
-    CommentModel.find({}, (error, foundComments) => {
+//comment seeding
+comment.get('/seed', (req, res) => {
+    CommentModel.create(commentSeed, (err, newComments) => {
+        if (err) {
+            res.status(400).json({ err: err.message });
+        }
+        res.status(200).json(newComments)
+    })
+})
+
+//index for that specific event
+comment.get('/:eventid', (req, res) => {
+    CommentModel.find({eventid: req.params.eventid}, (error, foundComments) => {
         if (error) {
             res.status(400).json({ error: error.message })
         }

--- a/models/commentModel.js
+++ b/models/commentModel.js
@@ -6,6 +6,7 @@ const commentSchema = new Schema({
     time: {type: Date, default: Date.now}, 
     content: String,
     rating: Number,
+    eventid: {type: Schema.Types.ObjectId, ref: 'Event'},
 })
 
 module.exports = model('Comment', commentSchema)

--- a/models/commentsSeed.js
+++ b/models/commentsSeed.js
@@ -1,0 +1,12 @@
+module.exports = [
+    {
+        username: "Ellyn",
+        content: "I've always wanted to go to Yosemite",
+        eventid: "607cee16d23e2e75483b9325"
+    },
+    {
+        username: "Jazmyne",
+        content: "can't wait!",
+        eventid: "607cee16d23e2e75483b9325"
+    }
+]

--- a/models/eventModel.js
+++ b/models/eventModel.js
@@ -19,7 +19,6 @@ const eventSchema = new Schema({
         description: String,
         },
     img: String,
-    comments: [String],
 })
 
 eventSchema.plugin(mongooseFuzzySearching, { fields: ['name', 'creator'] })

--- a/models/eventsSeed.js
+++ b/models/eventsSeed.js
@@ -16,7 +16,6 @@ module.exports = [
             description: "Hey guys it's Nick.  On May 5th (Wednesday), I'm gonna go hiking in the Yosemite Valley. Beginners are welcome but prepare for a long day, bring lunch."
         },
         img: "https://www.nps.gov/yose/planyourvisit/images/hiker-in-valleyweb.jpg?maxwidth=1200&maxheight=1200&autorotate=false",
-        comments: ["I've always wanted to go to Yosemite", "This is a great idea!", "I hope it doesn't rain"],
     },
     {
         name: "Haleakala Shuttle Mountain Biking",
@@ -35,7 +34,6 @@ module.exports = [
             description: "Hi everyone, I'm gonna be hosting a Mountain Biking event at Haleakala National Park in Hawaii on Wednesday April 28th. Hope everyone can make it!"
         },
         img: "https://cdn2.apstatic.com/photos/mtb/5079795_medium_1554329691.jpg",
-        comments: ["Haven't been biking since covid :(", "Looks beautiful!"],
     },
     {
         name: "Greenburgh Nature Center",
@@ -54,6 +52,5 @@ module.exports = [
             description: "Hi, on May 1st I'll be taking a short walk through the Greenburgh Nature Center woodland trail. Super easy, all are welcome."
         },
         img: "https://redtri.com/wp-content/uploads/2014/08/greenburgh-nature-center-fall1.jpg",
-        comments: ["An easy walk in the afternoon sounds perfect!"],
     }
 ]


### PR DESCRIPTION
- Comments now have an eventid field tying them to a specific event - this needs to be passed in the frontend when the comment is created.
- Comment index now takes the eventid as a parameter so you can get all the comments for that specific event
- Comment seeding is added, this currently is hardcoded with the eventid of what I have in my database - you can manually POST a quick comment with postman if you need or change seeding to match your DB
- All routes tested in postman and all are functioning
- Event model and seeding no longer contain a comments array